### PR TITLE
Fix for Navbar on mobile/Display if Gate is Online in Address Book

### DIFF
--- a/classes/stargate_address_book.py
+++ b/classes/stargate_address_book.py
@@ -99,11 +99,11 @@ class StargateAddressBook:
 
         return False
 
-    def set_fan_gate(self, name, gate_address, ip_address, is_black_hole=False):
+    def set_fan_gate(self, name, gate_address, ip_address, is_gate_online, is_black_hole=False):
         # TODO: Validate gate_address, ip_address
         # TODO: Ensure unique address
         fan_gates = self.get_fan_gates()
-        fan_gates[name] = { "name": name, "gate_address": gate_address, "ip_address": ip_address, "is_black_hole": is_black_hole }
+        fan_gates[name] = { "name": name, "gate_address": gate_address, "ip_address": ip_address, "is_gate_online": is_gate_online, "is_black_hole": is_black_hole }
         self.datastore.set("fan_gates", fan_gates)
 
 # ----

--- a/classes/stargate_address_manager.py
+++ b/classes/stargate_address_manager.py
@@ -67,9 +67,10 @@ class StargateAddressManager:
                     name = gate_config['name']
                     gate_address = literal_eval(gate_config['sg_address'])
                     ip_address = self.net_tools.get_ip(gate_config['ip'])
+                    is_gate_online = gate_config['status']
 
                     # Add it to the datastore
-                    self.address_book.set_fan_gate(name, gate_address, ip_address)
+                    self.address_book.set_fan_gate(name, gate_address, ip_address, is_gate_online)
 
                 self.log.log("Fan Gate Update: Success!")
                 self.cfg.set('fan_gate_last_update', str(datetime.now()))

--- a/web/address_book.htm
+++ b/web/address_book.htm
@@ -42,7 +42,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/config.htm
+++ b/web/config.htm
@@ -45,7 +45,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/debug.htm
+++ b/web/debug.htm
@@ -44,7 +44,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/help.htm
+++ b/web/help.htm
@@ -41,7 +41,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/index.htm
+++ b/web/index.htm
@@ -43,7 +43,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="#">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/info.htm
+++ b/web/info.htm
@@ -465,7 +465,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/js/address_book.js
+++ b/web/js/address_book.js
@@ -47,7 +47,7 @@ function load_address_book(){
         address = address_raw.join("");
 
         $("#presets").append('<div class="address-book-row address-book-row-'+value.type+' col-sm " onclick="window.location = \'index.htm?address=' +
-          address_string + '\';"><div class="address-book-col-planet-names">' + value.name + '</div><div class="address-book-col-glyphs">' + address + '</div><div class="address-book-is-online">' + is_gate_online  + '</div></div>' );
+          address_string + '\';"><div class="address-book-col-planet-names">' + value.name + '</div><div class="address-book-col-glyphs">' + address + '</div><div class="address-book-is-online">' + is_gate_online + '</div></div>' );
     });
 }
 

--- a/web/js/address_book.js
+++ b/web/js/address_book.js
@@ -22,7 +22,11 @@ function load_address_book(){
     $.each(addresses, function( index, value ) {
         address_raw = value.gate_address
         address_string = address_raw.join("-");
-
+        is_gate_online = value.is_gate_online
+        if (is_gate_online == 0){
+                is_gate_online = ""
+        } else {is_gate_online = "Online"}
+      
         $("#address_book_summary").html('')
         nameLookup = {
           "fan": "Subspace Gates",
@@ -43,7 +47,7 @@ function load_address_book(){
         address = address_raw.join("");
 
         $("#presets").append('<div class="address-book-row address-book-row-'+value.type+' col-sm " onclick="window.location = \'index.htm?address=' +
-          address_string + '\';"><div class="address-book-col-planet-names">' + value.name + '</div><div class="address-book-col-glyphs">' + address +  '</div></div>' );
+          address_string + '\';"><div class="address-book-col-planet-names">' + value.name + '</div><div class="address-book-col-glyphs">' + address + '</div><div class="address-book-is-online">' + is_gate_online  + '</div></div>' );
     });
 }
 

--- a/web/main.css
+++ b/web/main.css
@@ -331,8 +331,8 @@ html, body {
 .address-book-glyph {
   position:relative;
   float:left;
-  max-width:14%;
-  width: 14%
+  max-width:12%;
+  width: 12%
 }
 
 /* CONFIGURATION STYLES */

--- a/web/main.css
+++ b/web/main.css
@@ -244,7 +244,15 @@ html, body {
 
 .address-book-col-planet-names {
   float: left; /* fix for  buggy browsers */
-  width: 40%;
+  width: 20%;
+  min-width: 200px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.address-book-col-is-online {
+  float: left; /* fix for  buggy browsers */
+  width: 20%;
   min-width: 200px;
   font-size: 12px;
   font-weight: bold;

--- a/web/symbol_overview.htm
+++ b/web/symbol_overview.htm
@@ -43,7 +43,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 

--- a/web/wiring.htm
+++ b/web/wiring.htm
@@ -45,7 +45,7 @@
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="/">Stargate Command</a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
 


### PR DESCRIPTION
1) Bootstrap 5 compatibility change to fix broken collapsing Navbar on all htm pages.

2) Added is_gate_online that pulls 'status' data from the gate API request. Updated main.css and address_book.js to display if gate is online in the address book.

I didn't mean for these to be the same pull request...