### PR TITLE
Bugfix for storing type 'list' in config

### DIFF
--- a/classes/stargate_config.py
+++ b/classes/stargate_config.py
@@ -254,6 +254,10 @@ class StargateConfig:
         elif required_type == "dict":
             if not isinstance(test_value, dict ):
                 raise ValueError(f"{key} must be type `dict`")
+            
+        elif required_type == "list":
+            if not isinstance(test_value, list ):
+                raise ValueError(f"{key} must be type `list`")
 
         else:
             test_type = test_value.__class__.__name__


### PR DESCRIPTION
When trying to set a 'Local Stargate Address' using the web-interface, it returns an error popup without saving the address.
_Admin -> System Info -> Configure button, next to 'Local Stargate Address'_

I was able to trace it down to the type of 'list' not being recognized in the 'StargateConfig' class by the 'is_valid_value' function as a valid type to store in the config files.
_"Exception in set_local_address: Unknown record type. local_stargate_address requires list received list"_

---

Sidenote: it's currently difficult to figure out the exception, as the try-block its part of doesn't recognize ValueError type, only ValueUnchanged. I haven't edited this part as I don't have enough knowledge of the codebase to properly understand what its used in, but might be a good idea to rewrite it a little in the future:
```
def set(self, key, value):
    '''
    Validates, sets, and persists the key/value pair.
    If the input is invalid, ValueError is raised.
    '''
    try:
        value = self.is_valid_value(key, value) # raises ValueError if not valid
    except ValueUnchanged:
        pass # It's okay if the value wasn't changed

    # If we get here without exception, the value is valid and ready to store.
    self.__set_raw(key, value) # Sets and saves new value.
```