### PR TITLE
Add additional string to network check

### DIFF
--- a/classes/network_tools.py
+++ b/classes/network_tools.py
@@ -20,11 +20,13 @@ class NetworkTools:
         :return: True if there is a connection to the internet, and false if not.
         """
 
-        if 'open' in self.check_net(self.cloudflare):
+        cloudflare_check = self.check_net(self.cloudflare)
+        if 'open' in cloudflare_check or 'succeeded' in cloudflare_check:
             # self.log.log('We have Internet connection!')
             return True
 
-        if 'open' in self.check_net(self.google):
+        google_check = self.check_net(self.google)
+        if 'open' in google_check or 'succeeded' in google_check:
             # self.log.log('We have Internet connection!')
             return True
 


### PR DESCRIPTION
Add additional string check so it will work on other versions of raspberry pi os.

OS Version: Raspberry Pi OS Lite (32-bit) - Non Legacy Version
network_tools.py -> has_internet_access() returns false even with internet access.

Running the check_net command on my pi directly returns
```
pi@stargate:~ $ nc 1.1.1.1 53 -w 3 -zv
Connection to 1.1.1.1 53 port [tcp/domain] succeeded!
```

`open` does not appear in the output so it should be updated to check for additional strings such as `succeeded`