### PR TITLE
Fix finding the correct USB audio device

### DIFF
--- a/classes/stargate_audio.py
+++ b/classes/stargate_audio.py
@@ -122,7 +122,7 @@ class StargateAudio:
             for line in audio_devices:
                 if 'USB' in line:
                     return line[5]
-                return 1
+            return 1
         except FileNotFoundError:
             return 1
 


### PR DESCRIPTION
The function "get_usb_audio_device_card_number" returned "1" on the first iteration instead of looping through all lines first.