### PR TITLE
Feature: Show RPi temperature on System Info page

### DIFF
--- a/classes/StargateMilkyWay/stargate.py
+++ b/classes/StargateMilkyWay/stargate.py
@@ -27,6 +27,7 @@ class Stargate:
         self.electronics = app.electronics
         self.base_path = app.base_path
         self.net_tools = app.net_tools
+        self.temperature = app.temperature
         self.sw_updater = self.app.sw_updater
         self.schedule = app.schedule
         self.galaxy = app.galaxy

--- a/classes/temperature.py
+++ b/classes/temperature.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+
+class Temperature:
+
+    def __init__(self, log):
+        self.log = log
+
+    @staticmethod
+    def get_temperature():
+        """
+        A little helper that returns the output of the temperature command
+        By default the command is available on Raspberry Pi OS (Lite)
+        Command: `vcgencmd measure_temp | cut -d "=" -f2`
+
+        :return: returns the output as seen if run in a shell.
+        """
+        try:
+            result = subprocess.run(
+                'vcgencmd measure_temp | cut -d "=" -f2',
+                shell=True,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError as e:
+            return f"Error getting temperature: {e}"

--- a/classes/web_server.py
+++ b/classes/web_server.py
@@ -85,6 +85,7 @@ class StargateWebServer(SimpleHTTPRequestHandler):
                     "dialer_mode":                    self.stargate.dialer.type,
                     "hardware_mode":                  self.stargate.electronics.name,
                     "audio_volume":                   self.stargate.audio.volume,
+                    "temperature":                    self.stargate.temperature.get_temperature(),
                     "galaxy":                         self.stargate.galaxy
                 }
 

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ if GALAXY == "Milky Way":
 from stargate import Stargate
 from electronics import Electronics
 from network_tools import NetworkTools
+from temperature import Temperature
 
 class GateApplication:
 
@@ -104,6 +105,11 @@ class GateApplication:
 
         ### We'll use NetworkTools and Schedule throughout the app, initialize them here.
         self.net_tools = NetworkTools(self.log)
+
+        ### Temperature
+        self.temperature = Temperature(self.log)
+
+        ### Schedule
         self.schedule = schedule # Alias the class here so it can be used in other areas with a clear interface
 
         ### Check for new software updates ###

--- a/web/info.htm
+++ b/web/info.htm
@@ -376,6 +376,7 @@
             $('#dialerMode').html(data.dialer_mode)
             $('#hardwareMode').html(data.hardware_mode)
             $('#volumeAsPercent').html(data.audio_volume)
+            $('#temperature').text(data.temperature)
 
             $('#stats_dialing_failures').html(data.stats_dialing_failures)
             $('#stats_established_fan_count').html(data.stats_established_fan_count)
@@ -558,6 +559,7 @@
           <div class="system-info-row"><span class="system-info-col-names">Dialer Mode:&nbsp;&nbsp;&nbsp;</span><span class="system-info-col-values" id="dialerMode"></span></div>
           <div class="system-info-row"><span class="system-info-col-names">Hardware in Use:&nbsp;&nbsp;&nbsp;</span><span class="system-info-col-values" id="hardwareMode"></span></div>
           <div class="system-info-row"><span class="system-info-col-names">Audio Volume (%):&nbsp;&nbsp;&nbsp;</span><span class="system-info-col-values" id="volumeAsPercent"></span></div>
+          <div class="system-info-row"><span class="system-info-col-names">Temperature:&nbsp;&nbsp;&nbsp;</span><span class="system-info-col-values" id="temperature"></span></div>
         </div>
         <br>
         <h3>Lifetime Statistics</h3>

--- a/web/js/system_info.js
+++ b/web/js/system_info.js
@@ -94,6 +94,7 @@ function updateInfo(){
       $('#dialerMode').html(data.dialer_mode)
       $('#hardwareMode').html(data.hardware_mode)
       $('#volumeAsPercent').html(data.audio_volume)
+      $('#temperature').html(data.temperature)
 
       $('#stats_dialing_failures').html(data.stats_dialing_failures)
       $('#stats_established_fan_count').html(data.stats_established_fan_count)


### PR DESCRIPTION
Adds a 'Temperature' row to the System Info page which shows the (RPi's) current temperature.

Monitoring the Raspberry Pi’s temperature is especially important on warmer days—particularly in projects like this, where it's enclosed on all sides and struggles to dissipate heat.

The command used is: `vcgencmd measure_temp | cut -d "=" -f2`.
The first part, vcgencmd measure_temp, is a built-in command available on Raspberry Pi devices running the Lite OS. It retrieves the current temperature of the device. The second part, cut -d "=" -f2, splits the output at the equals sign (=) and returns the portion after it—typically something like 46.2'C.
