### PR TITLE
Fix "Unknown Address" for longer addresses

### DIFF
--- a/classes/stargate_address_manager.py
+++ b/classes/stargate_address_manager.py
@@ -40,8 +40,9 @@ class StargateAddressManager:
         return self.validator.is_valid(address)
 
     def get_planet_name_by_address(self, address):
-        # Get only the first 6 symbols
-        address_compare = address[0:6]
+        # Get all symbols except the last
+        # Works with 7,8, or 9 symbol addresses
+        address_compare = address[0:-1]
 
         entry = self.address_book.get_entry_by_address(address_compare)
         if entry:


### PR DESCRIPTION
When getting connected planet name it compares the first 6 dialed symbols to the entire address in the address book. So for 8 or 9 glyph addresses, it returns "Unknown Address"

Fix compare address so it works with 7,8,9 symbol addresses. Look at all symbols except point of origin.