### PR TITLE
[codex] Fix Pi audio, DHD detection, and WiFi setup

### DIFF
--- a/classes/StargateMilkyWay/dialers.py
+++ b/classes/StargateMilkyWay/dialers.py
@@ -211,6 +211,8 @@ class DHDv2:
         # A list for places to check for the DHD
         possible_files = [
             configured_port,
+            "/dev/serial/by-id/usb-SparkFun_SparkFun_Pro_Micro_HIDPC-if00",
+            *sorted(glob("/dev/serial/by-id/*SparkFun*Pro_Micro*")),
             "/dev/serial/by-id/usb-Adafruit_ItsyBitsy_32u4_5V_16MHz_HIDPC-if00",
             *sorted(glob("/dev/serial/by-id/*ItsyBitsy*")),
             "/dev/ttyACM0",

--- a/classes/StargateMilkyWay/dialers.py
+++ b/classes/StargateMilkyWay/dialers.py
@@ -1,4 +1,5 @@
 import os
+from glob import glob
 from time import sleep
 from serial.serialutil import SerialException
 import StargateCmdMessenger
@@ -52,7 +53,10 @@ class Dialer: # pylint: disable=too-few-public-methods
             # Get a Semaphore lock on the parent process so when the PyCmdMessenger class
             # prints to STDOUT, it doesn't step on STDOUT from other threads
             ### Connect to the DHD object. Will throw exception if not present
-            dhd = DHDv2(self.dhd_port, self.dhd_serial_baud_rate, self.log)
+            dhd_port = DHDv2.get_dhd_port(self.dhd_port)
+            if dhd_port is None:
+                raise SerialException
+            dhd = DHDv2(dhd_port, self.dhd_serial_baud_rate, self.log)
             self.log.log('DHDv2 Found. Connected.')
         except SerialException: # pylint: disable=try-except-raise
             raise
@@ -199,18 +203,24 @@ class DHDv2:
         self.color_symbols = color_tuple
 
     @staticmethod
-    def get_dhd_port():
+    def get_dhd_port(configured_port=None):
         """
         This is a simple helper function to help locate the port for the DHD
         :return: The file path for the DHD is returned. If it is not found, returns None.
         """
         # A list for places to check for the DHD
-        possible_files = ["/dev/serial/by-id/usb-Adafruit_ItsyBitsy_32u4_5V_16MHz_HIDPC-if00", "/dev/ttyACM0", "/dev/ttyACM1"]
+        possible_files = [
+            configured_port,
+            "/dev/serial/by-id/usb-Adafruit_ItsyBitsy_32u4_5V_16MHz_HIDPC-if00",
+            *sorted(glob("/dev/serial/by-id/*ItsyBitsy*")),
+            "/dev/ttyACM0",
+            "/dev/ttyACM1"
+        ]
 
         # Run through the list and check if the file exists.
         for file in possible_files:
             # If the file exists, return the path and end the function.
-            if os.path.exists(file):
+            if file and os.path.exists(file):
                 return file
 
         # If the DHD is not detected

--- a/classes/stargate_audio.py
+++ b/classes/stargate_audio.py
@@ -169,8 +169,8 @@ class StargateAudio:
                 ctl = 'defaults.ctl.card ' + str(self.get_usb_audio_device_card_number())
                 pcm = 'defaults.pcm.card ' + str(self.get_usb_audio_device_card_number())
                 # replace the lines in the alsa.conf file.
-                subprocess.run(['sudo', 'sed', '-i', f"/defaults.ctl.card /c\{ctl}", '/usr/share/alsa/alsa.conf'], check=False) #TODO: Check should be true
-                subprocess.run(['sudo', 'sed', '-i', f"/defaults.pcm.card /c\{pcm}", '/usr/share/alsa/alsa.conf'], check=False) #TODO: Check should be true
+                subprocess.run(['sudo', 'sed', '-i', f"s/^defaults\\.ctl\\.card .*/{ctl}/", '/usr/share/alsa/alsa.conf'], check=False) #TODO: Check should be true
+                subprocess.run(['sudo', 'sed', '-i', f"s/^defaults\\.pcm\\.card .*/{pcm}/", '/usr/share/alsa/alsa.conf'], check=False) #TODO: Check should be true
         except subprocess.CalledProcessError:
             self.log.log("Failed to set audio adapter config")
 

--- a/config/defaults-milkyway/config.json.dist
+++ b/config/defaults-milkyway/config.json.dist
@@ -174,7 +174,7 @@
     "max_value": 115200
   },
   "dhd_serial_port": {
-    "value": "/dev/serial/by-id/usb-Adafruit_ItsyBitsy_32u4_5V_16MHz_HIDPC-if00",
+    "value": "/dev/serial/by-id/usb-SparkFun_SparkFun_Pro_Micro_HIDPC-if00",
     "desc": "The USB Serial Device path for the DHD",
     "type": "str"
   },

--- a/install/functions.sh
+++ b/install/functions.sh
@@ -53,7 +53,7 @@ function apt_update_and_install() {
 
   # Install system-level dependencies
   echo 'Installing system-level dependencies...this may take a while.'
-  sudo apt-get install --no-install-recommends -y nano clang python3-dev python3-venv libasound2-dev avahi-daemon apache2 wireguard ufw python3-smbus i2c-tools netcat-traditional | sed 's/^/     /'
+  sudo apt-get install --no-install-recommends -y nano clang python3-dev python3-venv libasound2-dev avahi-daemon apache2 wireguard ufw python3-smbus i2c-tools iw netcat-traditional | sed 's/^/     /'
 }
 
 function init_venv() {
@@ -156,25 +156,39 @@ function disable_pwr_mgmt() {
       echo "Created $CONFIG file"
   fi
 
-  if grep -Fq '/sbin/iw wlan0 set power_save off' $CONFIG
+  WIFI_POWER_SAVE_OFF='command -v iw >/dev/null 2>&1 && iw dev wlan0 set power_save off || true'
+
+  if grep -Fq "$WIFI_POWER_SAVE_OFF" $CONFIG
   then
       echo 'WiFi power management is already disabled'
   else
       echo 'Disabling WiFi power management'
-      sudo sed -i '$i\\r\n/sbin\/iw wlan0 set power_save off\r\n' $CONFIG
+      TEMP_CONFIG=$(mktemp)
+      awk -v wifi_power_save_off="$WIFI_POWER_SAVE_OFF" '
+        /\/sbin\/iw wlan0 set power_save off/ { next }
+        /^exit 0$/ && !inserted { print wifi_power_save_off; inserted=1 }
+        { print }
+        END { if (!inserted) print wifi_power_save_off }
+      ' "$CONFIG" > "$TEMP_CONFIG"
+      sudo cp "$TEMP_CONFIG" "$CONFIG"
+      rm "$TEMP_CONFIG"
   fi
 }
 
 function disable_onboard_audio() {
   # Disable the onboard audio adapter
-  sudo cp /boot/config.txt /boot/config.bak
   echo 'Disabling RaspberryPi on-board audio adapter'
-  CONFIG='/boot/firmware/config.txt'
+  if [ -f '/boot/firmware/config.txt' ]; then
+    CONFIG='/boot/firmware/config.txt'
+  else
+    CONFIG='/boot/config.txt'
+  fi
+  sudo cp "$CONFIG" "$CONFIG.bak"
   SETTING='off'
-  sudo sed $CONFIG -i -r -e "s/^((device_tree_param|dtparam)=([^,]*,)*audio?)(=[^,]*)?/\1=$SETTING/"
-  if ! grep -q -E '^(device_tree_param|dtparam)=([^,]*,)*audio?=[^,]*' $CONFIG; then
+  sudo sed "$CONFIG" -i -r -e "s/^((device_tree_param|dtparam)=([^,]*,)*audio?)(=[^,]*)?/\1=$SETTING/"
+  if ! grep -q -E '^(device_tree_param|dtparam)=([^,]*,)*audio?=[^,]*' "$CONFIG"; then
     echo 'pattern not found, creating'
-    printf "dtparam=audio=$SETTING\n" >> $CONFIG
+    printf "dtparam=audio=$SETTING\n" | sudo tee -a "$CONFIG" > /dev/null
   fi
 }
 


### PR DESCRIPTION
## Problem observed after installing the Raspberry Pi image

On an original SG-1 gate running on a Raspberry Pi 3 B+, a fresh image installation can leave three hardware setup problems:

1. USB audio setup can target the wrong Raspberry Pi OS boot configuration path. Older images use `/boot/config.txt`, while newer images use `/boot/firmware/config.txt`. This can prevent the onboard audio adapter from being disabled and interfere with USB audio output.
2. The default DHD serial path points to an Adafruit ItsyBitsy device, but the original SG-1 DHD is exposed as `/dev/serial/by-id/usb-SparkFun_SparkFun_Pro_Micro_HIDPC-if00`. Users can therefore end up in keyboard fallback mode even though the DHD is connected.
3. WiFi power-saving setup invokes `iw` with an invalid command path and syntax, while the installer does not install `iw`. The boot-time command should never prevent startup or make WiFi unavailable after installation.

## What changed

- use the Raspberry Pi OS boot config path that actually exists when disabling onboard audio: `/boot/config.txt` or `/boot/firmware/config.txt`
- make ALSA card replacement portable and keep USB audio card selection working
- use `/dev/serial/by-id/usb-SparkFun_SparkFun_Pro_Micro_HIDPC-if00` as the default DHD path
- auto-detect SparkFun Pro Micro DHD paths at runtime, while retaining legacy ItsyBitsy and `/dev/ttyACM*` fallbacks
- install `iw` and disable only WiFi power saving with a non-blocking `rc.local` command; WiFi itself remains enabled


## Validation

- `bash -n install/functions.sh install/install.sh install/bootstrap.sh`
- `python3 -m py_compile classes/StargateMilkyWay/dialers.py classes/stargate_audio.py`
- `python3 -m json.tool config/defaults-milkyway/config.json.dist`
- `git diff --check`
- simulated `/etc/rc.local` migration from the old WiFi command
- simulated ALSA `defaults.ctl.card` and `defaults.pcm.card` replacement

